### PR TITLE
Fix bugs in metadata retrieval and front end

### DIFF
--- a/env.example
+++ b/env.example
@@ -14,4 +14,4 @@ NOTION_TOKEN=your_notion_integration_token_here
 NOTION_DATABASE_ID=your_notion_database_id_here
 
 # Server Configuration
-PORT=3000 
+PORT=3000

--- a/public/script.js
+++ b/public/script.js
@@ -266,7 +266,7 @@ function handleNewAnalysis() {
 // Handle retry
 function handleRetry() {
     if (currentResult) {
-        analyzeVideo(youtubeUrlInput.value, modelSelect.value);
+        analyzeVideo(youtubeUrlInput.value, modelSelect.value, promptSelect.value);
     } else {
         handleNewAnalysis();
     }
@@ -325,9 +325,13 @@ async function loadModels() {
     try {
         const response = await fetch('/api/models');
         const data = await response.json();
-        
-        // Store all models globally
-        allModels = data.models;
+
+        // Store all models globally, fallback to empty array on error
+        if (response.ok && Array.isArray(data.models)) {
+            allModels = data.models;
+        } else {
+            allModels = [];
+        }
         
         // Populate the select with all models
         populateModelSelect(allModels);

--- a/server.js
+++ b/server.js
@@ -152,7 +152,7 @@ async function getVideoMetadata(videoId) {
 
         const response = await axios.get(`https://www.googleapis.com/youtube/v3/videos`, {
             params: {
-                part: 'snippet,statistics',
+                part: 'snippet,statistics,contentDetails',
                 id: videoId,
                 key: apiKey
             }
@@ -170,7 +170,7 @@ async function getVideoMetadata(videoId) {
             description: video.snippet.description,
             viewCount: video.statistics.viewCount,
             likeCount: video.statistics.likeCount,
-            duration: video.snippet.duration,
+            duration: video.contentDetails.duration,
             tags: video.snippet.tags || []
         };
     } catch (error) {
@@ -286,7 +286,7 @@ async function generateTitle(transcript, videoInfo, model) {
         const titlePrompt = `You are an AI assistant that creates concise instructional titles for YouTube videos.
 
 Video Title: ${videoInfo.title}
-Video Description: ${videoInfo.description.substring(0, 500)}...
+Video Description: ${videoInfo.description.length > 500 ? videoInfo.description.substring(0, 500) + '...' : videoInfo.description}
 Transcript: ${transcript}
 
 Task: Write a concise 5–10 word instructional title summarizing the main focus of this video. The title should clearly instruct or convey the key action or topic of the content.


### PR DESCRIPTION
## Summary
- handle API errors when loading models
- retry analysis with selected prompt
- fetch video duration correctly
- truncate description only when needed in title prompt
- clean up env example file

## Testing
- `npm test` *(fails: Missing script)*
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_686f5bea5fb0832bb1c6e3ee6732b8ce