### PR TITLE
Add python transcript fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For each YouTube video, the app generates a comprehensive markdown report contai
 2. **Install dependencies**
    ```bash
    npm install
+   pip install youtube-transcript-api
    ```
 
 3. **Configure API keys**
@@ -156,8 +157,9 @@ The app includes specialized analysis templates for different video types:
 
 ### Transcript Handling
 
-The app uses multiple methods to extract transcripts:
-- **Primary**: youtube-transcript package with multiple language attempts
+- The app uses multiple methods to extract transcripts:
+- **Primary**: python `youtube-transcript-api` via a helper script with multi-language attempts
+- **Secondary**: youtube-transcript package
 - **Fallback**: youtube-captions-scraper package
 - **Verification**: YouTube Data API to check caption availability
 - **Graceful Degradation**: Full analysis using video description when transcripts aren't available

--- a/scripts/get_transcript.py
+++ b/scripts/get_transcript.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import sys
+import json
+from youtube_transcript_api import YouTubeTranscriptApi
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "Missing video id"}))
+        sys.exit(1)
+    video_id = sys.argv[1]
+    languages = [
+        'en', 'en-US', 'en-GB', 'en-CA', 'en-AU',
+        'de', 'fr', 'es', 'pt', 'it'
+    ]
+    try:
+        transcript_list = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+        print(json.dumps(transcript_list))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- install youtube-transcript-api and include in install docs
- integrate helper script `scripts/get_transcript.py`
- call helper as first attempt when fetching transcripts
- document updated transcript handling order

## Testing
- `node --check server.js`
- `pip install youtube-transcript-api` *(succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_6871da061f98832b98ecfa442d166f8d