### PR TITLE
Bug fix for YouTube Shorts URL parsing

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,9 @@ function extractVideoId(url) {
     const patterns = [
         /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
         /youtube\.com\/v\/([^&\n?#]+)/,
-        /youtube\.com\/watch\?.*v=([^&\n?#]+)/
+        /youtube\.com\/watch\?.*v=([^&\n?#]+)/,
+        /youtube\.com\/shorts\/([^&\n?#]+)/,
+        /youtube\.com\/live\/([^&\n?#]+)/
     ];
     
     for (const pattern of patterns) {
@@ -1651,7 +1653,13 @@ Format your response in clean markdown with proper headings and bullet points. F
     }
 });
 
-app.listen(PORT, () => {
-    console.log(`🚀 YouTube Analysis App running on http://localhost:${PORT}`);
-    console.log(`📝 Make sure to configure your API keys in the .env file`);
-}); 
+if (require.main === module) {
+    app.listen(PORT, () => {
+        console.log(`🚀 YouTube Analysis App running on http://localhost:${PORT}`);
+        console.log(`📝 Make sure to configure your API keys in the .env file`);
+    });
+}
+
+module.exports = {
+    extractVideoId
+};

--- a/test-extract-video-id.js
+++ b/test-extract-video-id.js
@@ -1,0 +1,23 @@
+const { extractVideoId } = require('./server');
+
+function test(url, expected) {
+  const result = extractVideoId(url);
+  if (result !== expected) {
+    console.error(`FAIL: ${url} -> ${result}, expected ${expected}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`PASS: ${url} -> ${result}`);
+  }
+}
+
+const tests = [
+  ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+  ['https://youtu.be/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+  ['https://www.youtube.com/embed/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+  ['https://www.youtube.com/shorts/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+  ['https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=1s', 'dQw4w9WgXcQ']
+];
+
+for (const [url, id] of tests) {
+  test(url, id);
+}


### PR DESCRIPTION
## Summary
- support `youtube.com/shorts` and `youtube.com/live` URLs in `extractVideoId`
- export `extractVideoId` and only start server when run directly
- add simple test for `extractVideoId`

## Testing
- `node test-extract-video-id.js`
- `node test-apify-mock.js`
- `node test-integration-complete.js`

------
https://chatgpt.com/codex/tasks/task_e_687c3b4fab88832bbed780f3c83483c0