### PR TITLE
Fix tests and cross-platform Python detection

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,7 +56,8 @@ function getTranscriptViaPython(videoId) {
         const { execSync } = require('child_process');
         try {
             const pythonVersion = execSync('python --version').toString().trim();
-            const pythonPath = execSync('where python').toString().trim();
+            const whichCmd = process.platform === 'win32' ? 'where python' : 'which python';
+            const pythonPath = execSync(whichCmd).toString().trim();
             console.log('Python version:', pythonVersion);
             console.log('Python path:', pythonPath);
         } catch (e) {


### PR DESCRIPTION
## Summary
- ensure python path detection works on Linux by using `which` when not on Windows
- enforce token check in `MockApifyClient`
- skip Apify integration tests if `APIFY_API_KEY` is not set
- skip complete integration test when Apify key is absent
- trim whitespace at end of test files

## Testing
- `npm install`
- `node test-apify-mock.js`
- `node test-apify-integration.js`
- `node test-integration-complete.js`


------
https://chatgpt.com/codex/tasks/task_e_687a03ff0c1c832b808e7ee70e20945f