### PR TITLE
Move default port to 8000

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -151,7 +151,7 @@ Brief description...
 1. **Install dependencies**: `npm install`
 2. **Configure API keys**: Copy `env.example` to `.env` and add your keys
 3. **Start the app**: `npm start`
-4. **Open browser**: Navigate to `http://localhost:3000`
+4. **Open browser**: Navigate to `http://localhost:8000`
 5. **Analyze videos**: Paste YouTube URLs and generate reports!
 
 ## 🎨 UI/UX Features

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,7 +27,7 @@ Get your YouTube Video Research App running in 5 minutes! 🚀
    ```env
    YOUTUBE_API_KEY=your_youtube_api_key_here
    OPENROUTER_API_KEY=your_openrouter_api_key_here
-   PORT=3000
+   PORT=8000
    ```
 
 ## Step 3: Start the App
@@ -36,7 +36,7 @@ Get your YouTube Video Research App running in 5 minutes! 🚀
 npm start
 ```
 
-Open your browser to: `http://localhost:3000`
+Open your browser to: `http://localhost:8000`
 
 ## Step 4: Test It Out
 
@@ -63,7 +63,7 @@ Open your browser to: `http://localhost:3000`
 
 **App won't start**
 - Make sure you ran `npm install`
-- Check that port 3000 isn't already in use
+- Check that port 8000 isn't already in use
 
 ## Cost Estimate
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For each YouTube video, the app generates a comprehensive markdown report contai
    OPENROUTER_API_KEY=your_openrouter_api_key_here
    NOTION_TOKEN=your_notion_integration_token_here
    NOTION_DATABASE_ID=your_notion_database_id_here
-   PORT=3000
+   PORT=8000
    ```
 
 4. **Start the application**
@@ -80,7 +80,7 @@ For each YouTube video, the app generates a comprehensive markdown report contai
    ```
 
 5. **Open your browser**
-   Navigate to `http://localhost:3000`
+   Navigate to `http://localhost:8000`
 
 ## 🔑 Getting API Keys
 
@@ -271,7 +271,7 @@ youtube-analysis-app/
 | `OPENROUTER_API_KEY` | OpenRouter API key | Yes |
 | `NOTION_TOKEN` | Notion integration token | No |
 | `NOTION_DATABASE_ID` | Notion database ID | No |
-| `PORT` | Server port (default: 3000) | No |
+| `PORT` | Server port (default: 8000) | No |
 
 ### Customization
 

--- a/env.example
+++ b/env.example
@@ -14,4 +14,4 @@ NOTION_TOKEN=your_notion_integration_token_here
 NOTION_DATABASE_ID=your_notion_database_id_here
 
 # Server Configuration
-PORT=3000
+PORT=8000

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ require('dotenv').config();
 let cachedPrompts = null;
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 8000;
 
 // Initialize Notion client
 const notion = new Client({


### PR DESCRIPTION
## Summary
- Default app port updated to 8000
- Documentation and env examples now reference http://localhost:8000

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8056d5b64832baa97634c8056ec0d